### PR TITLE
Notifications panel fixes

### DIFF
--- a/myapp/templates/base.html
+++ b/myapp/templates/base.html
@@ -44,9 +44,13 @@
                     </a>
                     <div class="dropdown-menu dropdown-menu-right dropdown-info"
                          aria-labelledby="navbarDropdownMenuLink-1"
-                         style="width: 360px !important;"> 
-                        <div class="overflow-auto" id="notificationsContainer"
-                            style="padding: 8px 16px 0px 16px;">
+                         style="width: 380px !important;"> 
+                        <div class="overflow-auto" id="notificationsContainer" style="padding: 8px 16px 0px 16px;">
+                            <div class="d-flex justify-content-center">
+                                <div class="spinner-border spinner-border-sm" role="status">
+                                  <span class="sr-only">Loading...</span>
+                                </div>
+                              </div>
                         </div>
                         <div class="dropdown-divider"></div>
                         <div id="actionsContainer">


### PR DESCRIPTION
Changelog:
* Fixed an issue where the unread notification count might appear several times when repeatedly clicking the notification bell icon 🔔 
* Fixed an issue where clicking the "X" button to delete a notification would also close the entire dropdown menu.
* The unread count is now managed on the client side when deleting notifications and marking them as read, and is refreshed from server every 30 seconds to show if there are any new notifications.
* On slow connections, when opening notifications panel, instead of being empty, it will now display old information until the new data has come from the server response. You may also see a loading spinner while waiting for the notifications to load.